### PR TITLE
Allow absolute paths, TEI without facsimiles

### DIFF
--- a/tei2dtsflat.py
+++ b/tei2dtsflat.py
@@ -625,7 +625,8 @@ def main():
     # set up 
     logging.basicConfig(level=args.loglevel)
     if args.docid is None:
-        docid = args.inputfile.lower().replace('.tei', '').replace('.xml', '')
+        name = Path(args.inputfile).name if args.inputfile[0] == "/" else args.inputfile
+        docid = name.lower().replace('.tei', '').replace('.xml', '')
         args.docid = docid
         
     # global counter for generated ids

--- a/tei2dtsflat.py
+++ b/tei2dtsflat.py
@@ -386,7 +386,7 @@ def parse_tei_pbs(doc, args):
 
     # read tei:facsimile element contents into facs_dict
     facs_dict = {}
-    for elem in doc.find('facsimile', XMLNS):
+    for elem in (doc.find('facsimile', XMLNS) or []):
         elem_id = elem.get(ns_pref_name('xml', 'id'))
         if elem_id:
             facs_dict[elem_id] = elem

--- a/tei2dtsflat.py
+++ b/tei2dtsflat.py
@@ -16,7 +16,6 @@
 
 import argparse
 import logging
-import time
 import xml.etree.ElementTree as ET
 import xml.sax
 from pathlib import Path


### PR DESCRIPTION
Hello! I'm working on the [Chronicle of Matthew of Edessa Editions](https://github.com/performant-software/chronicleME) project and I'm using your codebases to generate a DTSFlat file structure and serve DTS endpoints. Thanks for the great tools.

I had to make a couple of changes in order for this script to work with our TEI documents, so I thought I'd open a pull request since I imagine these are applicable to others.

- Using `args.inputfile` as the ID was causing conflicts, as the output directory is also based on the ID—so if `args.inputfile` was passed as an absolute path, the script would start writing output to the wrong directory. This change ensures that the output will always be written to the specified base directory.
- I wasn't sure if `facs_dict` needs to be populated in all cases, but since our documents don't have facsimiles, I just added a fallback to an empty list in case `doc.find('facsimile', XMLNS)` did not return anything, and it seems to work fine.
- Removed an unused import of `time` (not necessary, but just noticed it in the course of the other work!)